### PR TITLE
'steps' directory is not required in all paths with *.feature files

### DIFF
--- a/behave/runner_mp.py
+++ b/behave/runner_mp.py
@@ -38,7 +38,13 @@ class MultiProcRunner(Runner):
         feature_locations = [filename for filename in self.feature_locations()
                         if not self.config.exclude(filename)]
         # step definitions are needed here for formatters only
-        self.load_step_definitions(os.path.join(loc.dirname(), self.config.steps_dir) for loc in feature_locations)
+        steps_paths = []
+        for loc in feature_locations:
+            steps_path = os.path.join(loc.dirname(), self.config.steps_dir)
+            if os.path.isdir(steps_path):
+                steps_paths.append(steps_path)
+
+        self.load_step_definitions(steps_paths)
         features = parse_features(feature_locations, language=self.config.lang)
         self.features.extend(features)
         self.load_hooks()   # hooks themselves not used, but 'environment.py' loaded

--- a/behave/runner_mp.py
+++ b/behave/runner_mp.py
@@ -38,13 +38,7 @@ class MultiProcRunner(Runner):
         feature_locations = [filename for filename in self.feature_locations()
                         if not self.config.exclude(filename)]
         # step definitions are needed here for formatters only
-        steps_paths = []
-        for loc in feature_locations:
-            steps_path = os.path.join(loc.dirname(), self.config.steps_dir)
-            if os.path.isdir(steps_path):
-                steps_paths.append(steps_path)
-
-        self.load_step_definitions(steps_paths)
+        self.load_step_definitions()
         features = parse_features(feature_locations, language=self.config.lang)
         self.features.extend(features)
         self.load_hooks()   # hooks themselves not used, but 'environment.py' loaded


### PR DESCRIPTION
According to documentation https://behave.readthedocs.io/en/latest/gherkin.html?highlight=structure#layout-variations 'steps' directory is not required in all paths with *.feature files

**citation:**
the path to a “*name*.feature” file
This tells behave where to find the feature file. To find the steps directory behave will look in the directory containing the feature file. If it is not present, behave will look in the parent directory, and then its parent, and so on until it hits the root of the filesystem. The “environment.py” file, if present, must be in the same directory that contains the “steps” directory (not in the “steps” directory).