### PR TITLE
Use clock and perf_counter rather than time and monotonic

### DIFF
--- a/behave/reporter/summary.py
+++ b/behave/reporter/summary.py
@@ -13,10 +13,8 @@ from behave.formatter.base import StreamOpener
 
 if sys.version_info.major < 3 or sys.version_info.minor < 3:
     from time import clock
-elif sys.version_info.minor < 5:
-    from time import perf_counter as clock
 else:
-    from time import monotonic as clock
+    from time import perf_counter as clock
 
 
 # -- DISABLED: optional_steps = ('untested', 'undefined')

--- a/behave/reporter/summary.py
+++ b/behave/reporter/summary.py
@@ -4,17 +4,17 @@ Provides a summary after each test run.
 """
 
 from __future__ import absolute_import, division
-import six
 import sys
 from behave.model import ScenarioOutline
 from behave.model_core import Status
 from behave.reporter.base import Reporter
 from behave.formatter.base import StreamOpener
 
-if six.PY2:
+
+if sys.version_info.major < 3 or sys.version_info.minor < 3:
     from time import clock
 else:
-    from time import monotonic as clock
+    from time import perf_counter as clock
 
 
 # -- DISABLED: optional_steps = ('untested', 'undefined')

--- a/behave/reporter/summary.py
+++ b/behave/reporter/summary.py
@@ -13,8 +13,10 @@ from behave.formatter.base import StreamOpener
 
 if sys.version_info.major < 3 or sys.version_info.minor < 3:
     from time import clock
-else:
+elif sys.version_info.minor < 5:
     from time import perf_counter as clock
+else:
+    from time import monotonic as clock
 
 
 # -- DISABLED: optional_steps = ('untested', 'undefined')

--- a/behave/reporter/summary.py
+++ b/behave/reporter/summary.py
@@ -59,6 +59,7 @@ class SummaryReporter(Reporter):
         self.step_summary = {Status.passed.name: 0, Status.failed.name: 0,
                              Status.skipped.name: 0, Status.untested.name: 0,
                              Status.undefined.name: 0}
+        self.failed_scenarios = []
         self.start = clock()
 
     def feature(self, feature):

--- a/behave/reporter/summary.py
+++ b/behave/reporter/summary.py
@@ -4,12 +4,17 @@ Provides a summary after each test run.
 """
 
 from __future__ import absolute_import, division
+import six
 import sys
-from time import monotonic
 from behave.model import ScenarioOutline
 from behave.model_core import Status
 from behave.reporter.base import Reporter
 from behave.formatter.base import StreamOpener
+
+if six.PY2:
+    from time import clock
+else:
+    from time import monotonic as clock
 
 
 # -- DISABLED: optional_steps = ('untested', 'undefined')
@@ -54,7 +59,7 @@ class SummaryReporter(Reporter):
         self.step_summary = {Status.passed.name: 0, Status.failed.name: 0,
                              Status.skipped.name: 0, Status.untested.name: 0,
                              Status.undefined.name: 0}
-        self.start = monotonic()
+        self.start = clock()
         self.failed_scenarios = []
 
     def feature(self, feature):
@@ -78,7 +83,7 @@ class SummaryReporter(Reporter):
         self.stream.write(format_summary("feature", self.feature_summary))
         self.stream.write(format_summary("scenario", self.scenario_summary))
         self.stream.write(format_summary("step", self.step_summary))
-        duration = monotonic() - self.start
+        duration = clock() - self.start
         timings = (int(duration / 60.0), duration % 60)
         self.stream.write('Took %dm%02.3fs\n' % timings)
 

--- a/behave/reporter/summary.py
+++ b/behave/reporter/summary.py
@@ -11,10 +11,10 @@ from behave.reporter.base import Reporter
 from behave.formatter.base import StreamOpener
 
 
-if sys.version_info.major < 3 or sys.version_info.minor < 3:
-    from time import clock
-else:
+try:
     from time import perf_counter as clock
+except ImportError:
+    from time import clock
 
 
 # -- DISABLED: optional_steps = ('untested', 'undefined')

--- a/behave/reporter/summary.py
+++ b/behave/reporter/summary.py
@@ -5,6 +5,7 @@ Provides a summary after each test run.
 
 from __future__ import absolute_import, division
 import sys
+from time import monotonic
 from behave.model import ScenarioOutline
 from behave.model_core import Status
 from behave.reporter.base import Reporter
@@ -53,12 +54,11 @@ class SummaryReporter(Reporter):
         self.step_summary = {Status.passed.name: 0, Status.failed.name: 0,
                              Status.skipped.name: 0, Status.untested.name: 0,
                              Status.undefined.name: 0}
-        self.duration = 0.0
+        self.start = monotonic()
         self.failed_scenarios = []
 
     def feature(self, feature):
         self.feature_summary[feature.status.name] += 1
-        self.duration += feature.duration
         for scenario in feature:
             if isinstance(scenario, ScenarioOutline):
                 self.process_scenario_outline(scenario)
@@ -78,7 +78,8 @@ class SummaryReporter(Reporter):
         self.stream.write(format_summary("feature", self.feature_summary))
         self.stream.write(format_summary("scenario", self.scenario_summary))
         self.stream.write(format_summary("step", self.step_summary))
-        timings = (int(self.duration / 60.0), self.duration % 60)
+        duration = monotonic() - self.start
+        timings = (int(duration / 60.0), duration % 60)
         self.stream.write('Took %dm%02.3fs\n' % timings)
 
     def process_scenario(self, scenario):


### PR DESCRIPTION
These seem more appropriate for the purpose according to the documentation.

perf_counter is guaranteed to keep ticking during sleep, which might include timeouts while we are waiting for subprocesses to finish.

clock doesn't exactly have guarantees like that but claims to be "the function to use for benchmarking Python or timing algorithms."

I'm not actually using monotonic anymore so the branch name is incorrect, oh well